### PR TITLE
Allow None for AgentPluginBuildOptions.source_dir

### DIFF
--- a/agent_plugin_builder/agent_plugin_builder.py
+++ b/agent_plugin_builder/agent_plugin_builder.py
@@ -2,8 +2,10 @@ import logging
 from argparse import ArgumentParser
 from pathlib import Path
 
+from monkeytypes import AgentPluginManifest
+
 from .build_options import AgentPluginBuildOptions
-from .build_plugin import BUILD, DIST, build_agent_plugin
+from .build_plugin import BUILD, DIST, build_agent_plugin, get_agent_plugin_manifest
 from .setup_build_plugin_logging import add_file_handler, reset_logger, setup_logging
 
 logger = logging.getLogger(__name__)
@@ -49,7 +51,9 @@ def main():
     args = parser.parse_args()
     _setup_logging(args.verbosity)
     _log_arguments(args)
-    cmdline_build_options = AgentPluginBuildOptions(source_dir=args.source_dir)
+    manifest_file = get_agent_plugin_manifest(args.plugin_path)
+    source_dir = _get_source_dir(args.source_dir, manifest_file)
+    cmdline_build_options = AgentPluginBuildOptions(source_dir=source_dir)
     try:
         build_agent_plugin(
             args.plugin_path,
@@ -70,3 +74,9 @@ def _log_arguments(args):
 def _setup_logging(verbosity):
     reset_logger()
     setup_logging(verbosity)
+
+
+def _get_source_dir(source_dir: str | None, agent_plugin_manifest: AgentPluginManifest) -> str:
+    if source_dir is not None:
+        return source_dir
+    return f"{agent_plugin_manifest.name}_{agent_plugin_manifest.plugin_type.value}".lower()

--- a/agent_plugin_builder/agent_plugin_builder.py
+++ b/agent_plugin_builder/agent_plugin_builder.py
@@ -51,14 +51,15 @@ def main():
     args = parser.parse_args()
     _setup_logging(args.verbosity)
     _log_arguments(args)
-    manifest_file = get_agent_plugin_manifest(args.plugin_path)
-    source_dir = _get_source_dir(args.source_dir, manifest_file)
+    agent_plugin_manifest = get_agent_plugin_manifest(args.plugin_path)
+    source_dir = _get_source_dir(args.source_dir, agent_plugin_manifest)
     cmdline_build_options = AgentPluginBuildOptions(source_dir=source_dir)
     try:
         build_agent_plugin(
             args.plugin_path,
             args.build_dir_path,
             args.dist_dir_path,
+            agent_plugin_manifest,
             cmdline_build_options,
             on_build_dir_created=lambda dir: add_file_handler(dir),
         )

--- a/agent_plugin_builder/build_options.py
+++ b/agent_plugin_builder/build_options.py
@@ -21,7 +21,7 @@ class AgentPluginBuildOptions(InfectionMonkeyBaseModel):
         str,
         Field(
             title="The name of the source directory.",
-            default=None,
+            default="src",
         ),
     ]
     platform_dependencies: Annotated[

--- a/agent_plugin_builder/build_plugin.py
+++ b/agent_plugin_builder/build_plugin.py
@@ -35,6 +35,7 @@ def build_agent_plugin(
     plugin_path: Path,
     build_dir_path: Path,
     dist_dir_path: Path,
+    agent_plugin_manifest: AgentPluginManifest,
     build_options_overrides: AgentPluginBuildOptions,
     on_build_dir_created: Callable[[Path], None] | None = None,
 ):
@@ -48,6 +49,7 @@ def build_agent_plugin(
         If the directory does not exist, it will be created else it will be cleared
     :param dist_dir_path: Path to the dist directory.
         If the directory does not exist, it will be created
+    :param agent_plugin_manifest: Agent Plugin manifest.
     :param build_options_overrides: Build options to override the default build options.
         Also overrides any values loaded from the build options file.
     :param on_build_dir_created: Callback function to be called after the build directory is
@@ -80,7 +82,6 @@ def build_agent_plugin(
     if on_build_dir_created:
         on_build_dir_created(build_dir_path)
 
-    agent_plugin_manifest = get_agent_plugin_manifest(build_dir_path)
     build_options = _override_build_options(
         build_options=parse_agent_plugin_build_options(build_dir_path),
         overrides=build_options_overrides,

--- a/agent_plugin_builder/build_plugin.py
+++ b/agent_plugin_builder/build_plugin.py
@@ -84,7 +84,7 @@ def build_agent_plugin(
     build_options = _override_build_options(
         build_options=parse_agent_plugin_build_options(build_dir_path),
         overrides=build_options_overrides,
-        new_defaults=_get_default_build_options(agent_plugin_manifest),
+        new_defaults=_get_default_build_options(),
     )
     logger.debug(f"Using build options: {build_options.model_dump()}")
     create_agent_plugin_archive(build_dir_path, dist_dir_path, agent_plugin_manifest, build_options)
@@ -106,12 +106,8 @@ def get_agent_plugin_manifest(build_dir_path: Path) -> AgentPluginManifest:
         return AgentPluginManifest(**yaml.safe_load(f))
 
 
-def _get_default_build_options(
-    agent_plugin_manifest: AgentPluginManifest,
-) -> AgentPluginBuildOptions:
-    return AgentPluginBuildOptions(
-        source_dir=f"{agent_plugin_manifest.name}_{agent_plugin_manifest.plugin_type.value}".lower()
-    )
+def _get_default_build_options() -> AgentPluginBuildOptions:
+    return AgentPluginBuildOptions()
 
 
 def _override_build_options(
@@ -146,6 +142,7 @@ def create_agent_plugin_archive(
     :param source_dirname: Name of the plugin source directory.
     :param agent_plugin_manifest: Agent Plugin manifest.
     """
+
     dependency_method = build_options.platform_dependencies
     generate_vendor_directories(
         build_dir_path, build_options.source_dir, agent_plugin_manifest, dependency_method


### PR DESCRIPTION
Tested on the ssh-exploiter:

```shell
$ build_agent_plugin ~/source/ssh-exploiter/
2024-07-11 18:32:44,587 - Agent Plugin Builder started with arguments: plugin_path: *****/source/ssh-exploiter, build_dir_path: *****/source/agent-plugin-builder/build, dist_dir_path: *****/source/agent-plugin-builder/dist, source_dir: None, verbosity: -1
2024-07-11 18:32:44,587 - Reading plugin manifest file: *****/source/ssh-exploiter/manifest.yaml
2024-07-11 18:32:44,589 - Copying plugin code to build directory: *****/source/ssh-exploiter -> *****/source/agent-plugin-builder/build
2024-07-11 18:32:44,616 - Writing log file to *****/source/agent-plugin-builder/build/agent_plugin_builder.log
2024-07-11 18:32:44,616 - Build options not found, using defaults.
2024-07-11 18:32:44,617 - Generating vendor directories for plugin: SSH, dependency_method: PlatformDependencyPackagingMethod.SEPARATE
2024-07-11 18:32:44,617 - Generating requirements file
2024-07-11 18:32:45,688 - Requirements file generated
2024-07-11 18:33:01,864 - Generating config-schema for plugin: SSH
2024-07-11 18:33:01,864 - Creating source archive: *****/source/agent-plugin-builder/build/source.tar.gz 
2024-07-11 18:33:07,696 - Creating plugin archive: *****/source/agent-plugin-builder/build/SSH-exploiter.tar
2024-07-11 18:33:07,710 - Plugin archive created: *****/source/agent-plugin-builder/build/SSH-exploiter.tar
2024-07-11 18:33:07,710 - Copying plugin archive: *****/source/agent-plugin-builder/build/SSH-exploiter.tar -> *****/source/agent-plugin-builder/dist/SSH-exploiter.tar
$ ls -lh dist
total 9.2M
-rw-rw-r-- 1 user user 9.2M Jul 11 18:33 SSH-exploiter.tar
```